### PR TITLE
Add CRS and LocationName properties to ServiceDetails.

### DIFF
--- a/nredarwin/webservice.py
+++ b/nredarwin/webservice.py
@@ -398,6 +398,8 @@ class ServiceDetails(ServiceDetailsBase):
         ('overdue_message', 'overdueMessage'),
         ('ata', 'ata'),
         ('atd', 'atd'),
+        ('location_name', 'locationName'),
+        ('crs', 'crs'),
     ]
    
     def __init__(self, soap_data, *args, **kwargs):
@@ -456,6 +458,23 @@ class ServiceDetails(ServiceDetailsBase):
         A human readable string, not guaranteed to be a machine-parsable time
         """
         return self._atd
+
+    @property
+    def location_name(self):
+        """
+        Location Name
+
+        The name of the location from which the details of this service are being accessed
+        and to which the service attributes such as times correspond.
+        """
+        return self._location_name
+
+    @property
+    def crs(self):
+        """
+        The CRS code corresponding to the location_name property.
+        """
+        return self._crs
 
     @property
     def previous_calling_points(self):

--- a/test_nredarwin.py
+++ b/test_nredarwin.py
@@ -81,6 +81,8 @@ class ServiceDetailsTest(unittest.TestCase):
         self.assertEqual(self.service_details.operator_code, 'EM')
         self.assertEqual(self.service_details.ata, None)
         self.assertEqual(self.service_details.atd, None)
+        self.assertEqual(self.service_details.location_name, 'Manchester Piccadilly')
+        self.assertEqual(self.service_details.crs, 'MAN')
 
     def test_messages(self):
         self.assertFalse(self.service_details.is_cancelled)


### PR DESCRIPTION
GetServiceDetails call also returns these two properties, which were
not previously included in the ServiceDetails object.

Also adds checks to test suite for them.