### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ nre-darwin-py
 .. image:: https://travis-ci.org/robert-b-clarke/nre-darwin-py.svg?branch=master
     :target: https://travis-ci.org/robert-b-clarke/nre-darwin-py
 
-.. image:: https://pypip.in/v/nre-darwin-py/badge.png
+.. image:: https://img.shields.io/pypi/v/nre-darwin-py.svg
     :target: https://pypi.python.org/pypi//nre-darwin-py/
     :alt: Downloads
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nre-darwin-py))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nre-darwin-py`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.