### PR TITLE
update README for compability with old API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Basic usage
 Initiate a session::
 
     >>> from nredarwin.webservice import DarwinLdbSession
-    >>> darwin_sesh = DarwinLdbSession(wsdl="https://lite.realtime.nationalrail.co.uk/OpenLDBWS/wsdl.aspx", api_key="YOUR_KEY")
+    >>> darwin_sesh = DarwinLdbSession(wsdl="https://lite.realtime.nationalrail.co.uk/OpenLDBWS/wsdl.aspx?ver=2010-11-01", api_key="YOUR_KEY")
 
 Retrieve the departure board for Manchester Piccadilly station::
 


### PR DESCRIPTION
The current version of the API comes back with 401 Unauthorized on each request,
so the specific version needs to be specified (as per the National Rail
recommendations).